### PR TITLE
dont login user

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -11,7 +11,7 @@ def lint(session):
 
 
 @nox.session
-@nox.parametrize("django", ["2.2", "3.1", "3.2", "main"])
+@nox.parametrize("django", ["3.2", "4.0", "main"])
 def test(session, django):
     if django == "main" and not sys.version_info.minor >= 8:
         session.skip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,6 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Framework :: Django",
-    "Framework :: Django :: 2.2",
-    "Framework :: Django :: 3.0",
-    "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0"
 ]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -74,7 +74,7 @@ def test_view(client, user):
         )
 
         assert res.status_code == 200
-        assert client.session.get_expire_at_browser_close()
+        assert len(client.session.items()) == 0
 
         token = res.json()
         for field in ("access_token", "expires_in", "token_type", "refresh_token"):


### PR DESCRIPTION
backend.complete() дээр заавал хэрэглэгч буцаах ёстой юм байна, тэгэхээр хэрэглэгч байгаа эсэхийг шалгах шаардлагагүй байх. https://github.com/python-social-auth/social-core/blob/f27461df08bed02cdb8f95b828316a63751bb3a4/social_core/backends/base.py#L51.

client_id-г ажил хийхээсээ өмнө шалгаад алдаа буцаачихвал амар юм уу